### PR TITLE
feat(http): add generic http server interface definition to support m…

### DIFF
--- a/packages/common/interfaces/http/http-server.interfaces.ts
+++ b/packages/common/interfaces/http/http-server.interfaces.ts
@@ -1,0 +1,77 @@
+import { RequestMethod } from '../../enums';
+import { GlandApplicationOptions } from '../application/app-options.interface';
+
+export type ErrorHandler<TRequest = any, TResponse = any> = (error: any, req: TRequest, res: TResponse, next?: Function) => any;
+export type RequestHandler<TRequest = any, TResponse = any> = (req: TRequest, res: TResponse, next?: Function) => any;
+
+export interface HttpServer<TRequest = any, TResponse = any, ServerInstance = any> {
+  // Middleware handling
+  use(handler: RequestHandler<TRequest, TResponse> | ErrorHandler<TRequest, TResponse>): any;
+  use(path: string, handler: RequestHandler<TRequest, TResponse> | ErrorHandler<TRequest, TResponse>): any;
+  registerParserMiddleware(...args: any[]): any;
+
+  /**
+   * Add support for parsing request bodies if not already provided.
+   */
+  useBodyParser?(...args: any[]): any;
+
+  // HTTP methods
+  get(handler: RequestHandler<TRequest, TResponse>): any;
+  get(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  post(handler: RequestHandler<TRequest, TResponse>): any;
+  post(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  put(handler: RequestHandler<TRequest, TResponse>): any;
+  put(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  patch(handler: RequestHandler<TRequest, TResponse>): any;
+  patch(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  delete(handler: RequestHandler<TRequest, TResponse>): any;
+  delete(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  options(handler: RequestHandler<TRequest, TResponse>): any;
+  options(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  head(handler: RequestHandler<TRequest, TResponse>): any;
+  head(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  search?(handler: RequestHandler<TRequest, TResponse>): any;
+  search?(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  /**
+   * Handle all HTTP methods for a given route.
+   */
+  all(handler: RequestHandler<TRequest, TResponse>): any;
+  all(path: string, handler: RequestHandler<TRequest, TResponse>): any;
+
+  // Static assets
+  useStaticAssets?(...args: any[]): this;
+
+  // Views and templating
+  setBaseViewsDir?(path: string | string[]): this;
+  setViewEngine?(engineOrOptions: any): this;
+  render(response: any, view: string, options: any): any;
+
+  // Error handling
+  setErrorHandler?(handler: Function, prefix?: string): any;
+  setNotFoundHandler?(handler: Function, prefix?: string): any;
+
+  // CORS support
+  enableCors(options: any): any;
+
+  // Server lifecycle
+  listen(port: number | string, callback?: () => void): any;
+  listen(port: number | string, hostname: string, callback?: () => void): any;
+  close(): any;
+
+  // Instance and initialization
+  getInstance(): ServerInstance;
+  initHttpServer(options: GlandApplicationOptions): void;
+  getHttpServer(): any;
+  init?(): Promise<void>;
+
+  // Adapter metadata
+  getType(): string; //adapter type (e.g., "express", "koa", "gland")
+}


### PR DESCRIPTION
…ultiple frameworks and enhance type safety implement comprehensive http server interface covering middleware handling all standard http methods static asset serving view engine configuration error handling cors support server lifecycle management and adapter metadata exposure define generic request response types and server instance type for framework agnostic implementation include methods for body parser registration route-specific and global middleware application http verb routing including get post put patch delete options head search and all static file serving view template rendering setup error handler registration cors enablement server startup shutdown and instance retrieval provide base structure for creating framework adapters while maintaining consistent api surface improve type safety with generic request response constraints support optional method implementations for flexibility enable creation of custom http adapters that integrate with gland application core while preserving framework-specific features